### PR TITLE
Extend Makefile with help task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,11 @@ endif
 
 CPPFLAGS := -g -Werror -Wpedantic -Wall -Wextra -std=c++17
 
-all: $(EXECUTABLE)
+.PHONY: all
+all: build 
 
+.PHONY: build
+build: $(EXECUTABLE) ## Build file editor
 $(EXECUTABLE): $(BUILD)file_editor.o $(BUILD)send_debug.o $(BUILD)main.o
 		g++ $(BUILD)main.o $(BUILD)file_editor.o $(BUILD)send_debug.o -o $(EXECUTABLE)
 
@@ -32,10 +35,12 @@ $(BUILD)file_editor.o: $(SOURCE)file_editor.cpp $(INCLUDES)file_editor.hpp
 $(BUILD)main.o: $(SOURCE)main.cpp
 		g++ $(CPPFLAGS) -c $(SOURCE)main.cpp -I $(INCLUDES) -o $(BUILD)main.o
 
-debug: $(SOURCE)recv_debug.cpp
+.PHONY: debug
+debug: $(SOURCE)recv_debug.cpp ## Debug build
 		g++ $(CPPFLAGS) $(SOURCE)recv_debug.cpp -o $(BIN)recv.out
 
-clean:
+.PHONY: clean
+clean: ## Clean up all build artifacts
         ifneq ("$(wildcard $(EXECUTABLE))","")
 		    -$(DELETE) $(EXECUTABLE)
         endif
@@ -48,3 +53,7 @@ clean:
         ifneq ("$(wildcard $(BUILD)main.o)","")
 		    -$(DELETE) $(BUILD)main.o
         endif
+
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This PR introduces a help output for `make`.  
When calling `make help` it will display all `make` tasks that contain a description (two hashes comment). 

![image](https://user-images.githubusercontent.com/9566732/163346278-adac2145-ddcc-456d-9e69-2eb3c5994a39.png)

I'm not sure about the `debug` task, so please adjust the description for it.