### PR TITLE
Add script for easy clang formatting of the whole project

### DIFF
--- a/clang-format-all.sh
+++ b/clang-format-all.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+find src include \
+  \( -name '*.c' \
+  -o -name '*.cc' \
+  -o -name '*.cpp' \
+  -o -name '*.h' \
+  -o -name '*.hh' \
+  -o -name '*.hpp' \) \
+  -exec clang-format -style=file -i --verbose {} \;


### PR DESCRIPTION
`clang-format` doesn't allwow expressions to format a dir and its subdirs.
Therefore, this simple shell script will find all C/C++ files in the `src` and `include` dir and format them with `clang-format`.
